### PR TITLE
Remove unused local variables "version", "longlen", "shortlen", and "flags"

### DIFF
--- a/fortune.py
+++ b/fortune.py
@@ -1,3 +1,4 @@
+
 # fortune.py -- chooses a random fortune, as the fortune(8) program in
 #               the BSD-games package does
 #
@@ -50,10 +51,10 @@ def get(filename):
     datfile = open(filename+'.dat', 'r')
     data = datfile.read(5 * LONG_SIZE)
     if is_64_bit:
-        _, n1, n2, _, _, s1, s2, _, _ = struct.unpack('!10L', data)
+        _, n1, n2, s1, s2 = struct.unpack('!10L', data)[:5]
         numstr   = n1 + (n2 << 32)
     else:
-        _, numstr, _, _, _ = struct.unpack('5l', data)
+        _, numstr = struct.unpack('5l', data)[:2]
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes
@@ -76,7 +77,7 @@ def get(filename):
     quotation = file.read(end-start)
     L=string.split(quotation, '\n')
     while string.strip(L[-1]) == delimiter or string.strip(L[-1]) == "":
-        L=L[:-1]
+        L = L[:-1]
     return string.join(L, '\n')
 
 if __name__ == '__main__':

--- a/fortune.py
+++ b/fortune.py
@@ -53,11 +53,11 @@ def get(filename):
     if is_64_bit:
         _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
         numstr   = n1 + (n2 << 32)
-        longlen  = l1 + (l2 << 32)
         shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
         _, numstr, longlen, shortlen, flags = struct.unpack('5l', data)
+        _, numstr, _, shortlen, flags = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes

--- a/fortune.py
+++ b/fortune.py
@@ -1,4 +1,3 @@
-
 # fortune.py -- chooses a random fortune, as the fortune(8) program in
 #               the BSD-games package does
 #
@@ -51,11 +50,9 @@ def get(filename):
     datfile = open(filename+'.dat', 'r')
     data = datfile.read(5 * LONG_SIZE)
     if is_64_bit:
-        _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
+        _, n1, n2, _, _, s1, s2, _, _ = struct.unpack('!10L', data)
         numstr   = n1 + (n2 << 32)
-        flags    = f1 + (f2 << 32)
     else:
-        _, numstr, longlen, _, flags = struct.unpack('5l', data)
         _, numstr, _, _, _ = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)

--- a/fortune.py
+++ b/fortune.py
@@ -53,11 +53,10 @@ def get(filename):
     if is_64_bit:
         _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
         numstr   = n1 + (n2 << 32)
-        shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
-        _, numstr, longlen, shortlen, flags = struct.unpack('5l', data)
-        _, numstr, _, shortlen, flags = struct.unpack('5l', data)
+        _, numstr, longlen, _, flags = struct.unpack('5l', data)
+        _, numstr, _, _, flags = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes

--- a/fortune.py
+++ b/fortune.py
@@ -51,7 +51,7 @@ def get(filename):
     datfile = open(filename+'.dat', 'r')
     data = datfile.read(5 * LONG_SIZE)
     if is_64_bit:
-        _, _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
+        _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
         numstr   = n1 + (n2 << 32)
         longlen  = l1 + (l2 << 32)
         shortlen = s1 + (s2 << 32)

--- a/fortune.py
+++ b/fortune.py
@@ -56,7 +56,7 @@ def get(filename):
         flags    = f1 + (f2 << 32)
     else:
         _, numstr, longlen, _, flags = struct.unpack('5l', data)
-        _, numstr, _, _, flags = struct.unpack('5l', data)
+        _, numstr, _, _, _ = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes


### PR DESCRIPTION
SonarQube Issues:
 Remove the unused local variable "version".
Remove the unused local variable "longlen".
Remove the unused local variable "shortlen".
Remove the unused local variable "flags".