### PR TITLE
Refactor Code by Removing Unused Local Variables: version, longlen, shortlen, flags

### DIFF
--- a/fortune.py
+++ b/fortune.py
@@ -51,7 +51,7 @@ def get(filename):
     datfile = open(filename+'.dat', 'r')
     data = datfile.read(5 * LONG_SIZE)
     if is_64_bit:
-        _, _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
+        _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!9L', data)
         numstr   = n1 + (n2 << 32)
         longlen  = l1 + (l2 << 32)
         shortlen = s1 + (s2 << 32)

--- a/fortune.py
+++ b/fortune.py
@@ -57,7 +57,7 @@ def get(filename):
         shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
-        _, numstr, _, shortlen, flags = struct.unpack('5l', data)
+        _, numstr, _, _, flags = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes

--- a/fortune.py
+++ b/fortune.py
@@ -57,7 +57,7 @@ def get(filename):
         shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
-        _, numstr, longlen, shortlen, flags = struct.unpack('5l', data)
+        _, numstr, _, shortlen, flags = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes

--- a/fortune.py
+++ b/fortune.py
@@ -57,7 +57,7 @@ def get(filename):
         shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
-        _, numstr, _, _, flags = struct.unpack('5l', data)
+        _, numstr, _, _ = struct.unpack('5l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes


### PR DESCRIPTION
SonarQube Issues:
 Remove the unused local variable "version".
Remove the unused local variable "longlen".
Remove the unused local variable "shortlen".
Remove the unused local variable "flags".