### PR TITLE
Remove unused local variables "version" and "longlen"

### DIFF
--- a/fortune.py
+++ b/fortune.py
@@ -51,7 +51,7 @@ def get(filename):
     datfile = open(filename+'.dat', 'r')
     data = datfile.read(5 * LONG_SIZE)
     if is_64_bit:
-        _, _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!10L', data)
+        _, n1, n2, l1, l2, s1, s2, f1, f2 = struct.unpack('!9L', data)
         numstr   = n1 + (n2 << 32)
         longlen  = l1 + (l2 << 32)
         shortlen = s1 + (s2 << 32)


### PR DESCRIPTION
SonarQube Issues:
 Remove the unused local variable "version".