### PR TITLE
Remove unused local variable and address other SonarQube findings

### DIFF
--- a/fortune.py
+++ b/fortune.py
@@ -57,7 +57,7 @@ def get(filename):
         shortlen = s1 + (s2 << 32)
         flags    = f1 + (f2 << 32)
     else:
-        _, numstr, longlen, shortlen, _ = struct.unpack('5l', data)
+        _, numstr, longlen, _ = struct.unpack('4l', data)
 
     delimiter = datfile.read(1)
     datfile.read(3)                     # Throw away padding bytes


### PR DESCRIPTION
SonarQube Issues:
 Remove the unused local variable "shortlen".