### PR TITLE
Refactor code to use built-in logging functions instead of print statements

### DIFF
--- a/letters.py
+++ b/letters.py
@@ -96,7 +96,7 @@ def play_once():
 
         except (EOFError, KeyboardInterrupt):
             # End-Of-File : the user
-            print '\nOK; give up if you like.'
+            print('\nOK; give up if you like.')
             return
 
         handle_query(query, possibilities, asked, letter_stats, choice)


### PR DESCRIPTION
SonarQube Issues:
 Replace print statement by built-in function.